### PR TITLE
Introduce Mikro ORM to backend

### DIFF
--- a/back/dist/server.js
+++ b/back/dist/server.js
@@ -7,6 +7,8 @@ const express_1 = __importDefault(require("express"));
 const path_1 = __importDefault(require("path"));
 const cors_1 = __importDefault(require("cors"));
 const express_session_1 = __importDefault(require("express-session"));
+const mysql_1 = require("@mikro-orm/mysql");
+const mikro_orm_config_1 = __importDefault(require("./mikro-orm.config"));
 // Primer servidor (en el puerto 3000)
 const app = (0, express_1.default)();
 const port = 3000;
@@ -43,6 +45,12 @@ app.get('/api', (req, res) => {
 app.get('/home', (req, res) => {
     res.sendFile(path_1.default.join(__dirname, 'dist', 'index.html'));
 });
-app.listen(port, () => {
-    console.log(`Servidor Express corriendo en http://localhost:${port}`);
+async function start() {
+    await mysql_1.MikroORM.init(mikro_orm_config_1.default);
+    app.listen(port, () => {
+        console.log(`Servidor Express corriendo en http://localhost:${port}`);
+    });
+}
+start().catch((err) => {
+    console.error('Error iniciando la aplicaci\u00f3n', err);
 });

--- a/back/package.json
+++ b/back/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "npm run build && electron .  ",
     "build": "tsc",
-    "server": "ts-node src/server.ts"
+    "server": "ts-node src/server.ts",
+    "mikro-orm": "mikro-orm"
   },
   "keywords": [],
   "author": "",
@@ -23,7 +24,9 @@
     "jsonwebtoken": "^9.0.2",
     "mysql2": "^3.11.4",
     "node-thermal-printer": "^4.4.3",
-    "usb": "^2.14.0"
+    "usb": "^2.14.0",
+    "@mikro-orm/core": "^6.2.1",
+    "@mikro-orm/mysql": "^6.2.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
@@ -31,6 +34,7 @@
     "@types/express": "^5.0.0",
     "@types/express-session": "^1.18.0",
     "@types/jsonwebtoken": "^9.0.7",
+    "@mikro-orm/cli": "^6.2.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.7.2"
   }

--- a/back/src/entities/Categoria.ts
+++ b/back/src/entities/Categoria.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'categoria' })
+export class Categoria {
+  @PrimaryKey({ fieldName: 'id_categoria' })
+  id!: number;
+
+  @Property()
+  nombre!: string;
+}

--- a/back/src/entities/DetalleVenta.ts
+++ b/back/src/entities/DetalleVenta.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'detalle_venta' })
+export class DetalleVenta {
+  @PrimaryKey({ fieldName: 'id_venta' })
+  id_venta!: number;
+
+  @PrimaryKey({ fieldName: 'id_producto' })
+  id_producto!: number;
+
+  @Property()
+  cantidad!: number;
+
+  @Property()
+  precio_unitario!: number;
+}

--- a/back/src/entities/Producto.ts
+++ b/back/src/entities/Producto.ts
@@ -1,0 +1,25 @@
+import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'productos' })
+export class Producto {
+  @PrimaryKey({ fieldName: 'id_producto' })
+  id!: number;
+
+  @Property({ fieldName: 'id_categoria' })
+  id_categoria!: number;
+
+  @Property()
+  nombre_producto!: string;
+
+  @Property()
+  precio_compra!: number;
+
+  @Property()
+  precio_venta!: number;
+
+  @Property()
+  stock!: number;
+
+  @Property()
+  codigo_barras!: string;
+}

--- a/back/src/entities/Usuario.ts
+++ b/back/src/entities/Usuario.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'usuarios' })
+export class Usuario {
+  @PrimaryKey({ fieldName: 'id_usuario' })
+  id_usuario!: number;
+
+  @Property()
+  nombre!: string;
+
+  @Property()
+  apellido!: string;
+
+  @Property()
+  username!: string;
+
+  @Property()
+  contrasena!: string;
+}

--- a/back/src/entities/Venta.ts
+++ b/back/src/entities/Venta.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity({ tableName: 'ventas' })
+export class Venta {
+  @PrimaryKey({ fieldName: 'id_venta' })
+  id_venta!: number;
+
+  @Property({ fieldName: 'id_usuario' })
+  id_usuario!: number;
+
+  @Property()
+  fecha_venta!: Date;
+
+  @Property()
+  total!: number;
+
+  @Property()
+  monto_extra?: number;
+}

--- a/back/src/mikro-orm.config.ts
+++ b/back/src/mikro-orm.config.ts
@@ -1,0 +1,18 @@
+import { Options } from '@mikro-orm/core';
+import { Categoria } from './entities/Categoria';
+import { Producto } from './entities/Producto';
+import { Usuario } from './entities/Usuario';
+import { Venta } from './entities/Venta';
+import { DetalleVenta } from './entities/DetalleVenta';
+
+const config: Options = {
+  entities: [Categoria, Producto, Usuario, Venta, DetalleVenta],
+  dbName: process.env.DB_NAME || 'negocio',
+  user: process.env.DB_USER || 'negocio',
+  password: process.env.DB_PASSWORD || 'negocio',
+  host: process.env.DB_HOST || 'localhost',
+  port: Number(process.env.DB_PORT) || 3306,
+  type: 'mysql',
+};
+
+export default config;

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -2,6 +2,8 @@ import express, { Request, Response } from 'express';
 import path from 'path';
 import cors from 'cors';
 import session from 'express-session';
+import { MikroORM } from '@mikro-orm/mysql';
+import mikroConfig from './mikro-orm.config';
 
 
 // Primer servidor (en el puerto 3000)
@@ -52,6 +54,13 @@ app.get('/home', (req: Request, res: Response) => {
   res.sendFile(path.join(__dirname, 'dist', 'index.html'));
 });
 
-app.listen(port, () => {
-  console.log(`Servidor Express corriendo en http://localhost:${port}`);
+async function start() {
+  await MikroORM.init(mikroConfig);
+  app.listen(port, () => {
+    console.log(`Servidor Express corriendo en http://localhost:${port}`);
+  });
+}
+
+start().catch((err) => {
+  console.error('Error iniciando la aplicaci\u00f3n', err);
 });


### PR DESCRIPTION
## Summary
- install Mikro ORM dependencies
- configure ORM in new `mikro-orm.config.ts`
- add entity definitions for existing tables
- initialize ORM in the backend server

## Testing
- `npx tsc` *(fails: Cannot find module '@mikro-orm/core')*
- `npm install` *(fails: 403 Forbidden - registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688a71cd39e8832db93a50cd9d1b4c78